### PR TITLE
Fixes issue where new items would show all fields

### DIFF
--- a/app/models/issue_patch.rb
+++ b/app/models/issue_patch.rb
@@ -24,7 +24,7 @@ module IssuePatch
 		 # having the order in this way sets the instance variable as originally
 		 # intended
 		 status_is = self.status_id
-		 self.status_id = status_id_was
+		 self.status_id = status_id_was unless status_id_was.nil?
 
 		 # store the result as a hash of field, rule
 		 result_was = workflow_rule_by_attribute_without_aggregate_rules(user)


### PR DESCRIPTION
Fixes issue #4 

Issue occurs because there is no status_was for a new item, returning
nil for self.status_id

Because there is no actual 'optional' workflow rule, nil rules were
passed in as blank strings.

This patch simply stops the self.status_id reassignment if there is no
status_was, resulting in the unless conditional for the result
evaluating true
